### PR TITLE
Fix crash when we fail to parse the JSON response from the server.

### DIFF
--- a/Auth0Client/Auth0Client.h
+++ b/Auth0Client/Auth0Client.h
@@ -43,6 +43,6 @@
 
 - (void)getDelegationToken:(NSString *)targetClientId options:(NSMutableDictionary *)options withCompletionHandler:(void (^)(NSMutableDictionary* delegationResult))block;
 
-- (void)getUserInfo:(NSString *)accessToken withCompletionHandler:(void (^)(NSMutableDictionary* profile))block;
+- (void)getUserInfo:(NSString *)accessToken success:(void (^)(NSMutableDictionary* profile))success failure:(void (^)(NSMutableDictionary* error))failure;
 
 @end


### PR DESCRIPTION
Fixes a crash when data in getUserInfo call is nil and cannot be parsed into a JSON object - separates out the completion handler into success and failure blocks, creates an error in the getUserInfo method and returns this error in an NSMutableDictionary. 

I am also creating a PR in the Stingray repo to ensure all calls to getUserInfo use the appropriate method signature and handle the error appropriately.

I'm open to suggestions for the way the error text is worded.