### PR TITLE
ENGAGE-198875 :Fix NSInvalidArgumentException in __49-[Auth0Client getUserInfo:withCompletionHandler:]_block_invoke

### DIFF
--- a/Auth0Client/Auth0Client.m
+++ b/Auth0Client/Auth0Client.m
@@ -161,7 +161,7 @@ NSString *DefaultCallback = @"https://%@/mobile";
 		 }
 		 
 		 [self getUserInfo:accessToken success:^(NSMutableDictionary* profile) {
-			 [parseData setObject:profile forKey:@"profile"];
+			 [parseData setObject:profile?: [NSNull null] forKey:@"profile"];
 			 _auth0User = [Auth0User auth0User:parseData];
 			 block(nil);
          } failure:^(NSMutableDictionary *error) {
@@ -212,7 +212,7 @@ NSString *DefaultCallback = @"https://%@/mobile";
 		 }
 		 
 		 [self getUserInfo:auth0_accessToken success:^(NSMutableDictionary* profile) {
-			 [parseData setObject:profile forKey:@"profile"];
+			 [parseData setObject:profile?: [NSNull null] forKey:@"profile"];
 			 _auth0User = [Auth0User auth0User:parseData];
 			 block(nil);
          } failure:^(NSMutableDictionary* error) {

--- a/Auth0Client/Auth0Client.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Auth0Client/Auth0Client.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Added [NSNull null] check to avoid getting nil into dictionary causing invalid argument exception.